### PR TITLE
Fixed build errors in Tidbit firmware due to mismatched return type in keymaps

### DIFF
--- a/keymaps/19keypad/keymap.c
+++ b/keymaps/19keypad/keymap.c
@@ -72,12 +72,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-void encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
   if (clockwise) {
     tap_code(KC_VOLU);
   } else {
     tap_code(KC_VOLD);
   }  
+  return true;
 }
 
 layer_state_t layer_state_set_user(layer_state_t state) {

--- a/keymaps/4rotary/keymap.c
+++ b/keymaps/4rotary/keymap.c
@@ -87,7 +87,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-void encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
   /* With an if statement we can check which encoder was turned. */
   if (index == 0) { /* First encoder */
     if (clockwise) {
@@ -114,6 +114,7 @@ void encoder_update_user(uint8_t index, bool clockwise) {
       tap_code(KC_VOLD);
     }  
   }
+  return true;
 }
 
 layer_state_t layer_state_set_user(layer_state_t state) {

--- a/keymaps/default/keymap.c
+++ b/keymaps/default/keymap.c
@@ -82,12 +82,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-void encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
   if (clockwise) {
     tap_code(KC_VOLU);
   } else {
     tap_code(KC_VOLD);
-  }  
+  } 
+  return true;
 }
 
 layer_state_t layer_state_set_user(layer_state_t state) {

--- a/keymaps/oled/keymap.c
+++ b/keymaps/oled/keymap.c
@@ -129,12 +129,13 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-void encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
   if (clockwise) {
     tap_code(KC_VOLU);
   } else {
     tap_code(KC_VOLD);
-  }  
+  } 
+  return true;
 }
 
 layer_state_t layer_state_set_user(layer_state_t state) {

--- a/keymaps/via/keymap.c
+++ b/keymaps/via/keymap.c
@@ -71,12 +71,13 @@ void matrix_scan_user(void) {
   matrix_scan_remote_kb();
 }
 
-void encoder_update_user(uint8_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
   if (clockwise) {
     tap_code(KC_VOLU);
   } else {
     tap_code(KC_VOLD);
-  }  
+  } 
+  return true;
 }
 
 void led_set_kb(uint8_t usb_led) {


### PR DESCRIPTION
All keymaps now build without error with QMK CLI.

It fixes the following issues:
- https://github.com/nullbitsco/tidbit/issues/8
- https://github.com/nullbitsco/tidbit/issues/6