### PR TITLE
Fix 0 key for 2U builds

### DIFF
--- a/keymaps/default/keymap.c
+++ b/keymaps/default/keymap.c
@@ -43,7 +43,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_KP_7, KC_KP_8,  KC_KP_9,        KC_KP_PLUS, \
   KC_KP_4, KC_KP_5,  KC_KP_6,        KC_NO, \
   KC_KP_1, KC_KP_2,  KC_KP_3,        TD(TD_ENTER_LAYER), \
-  KC_NO,   KC_KP_0,  KC_KP_DOT,      KC_NO \
+  KC_KP_0, KC_KP_0,  KC_KP_DOT,      KC_NO \
   ),
   // Function layer (numpad)
   [_FUNC] = LAYOUT(

--- a/keymaps/oled/keymap.c
+++ b/keymaps/oled/keymap.c
@@ -43,7 +43,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   KC_KP_7, KC_KP_8,  KC_KP_9,        KC_KP_PLUS, \
   KC_KP_4, KC_KP_5,  KC_KP_6,        KC_NO, \
   KC_KP_1, KC_KP_2,  KC_KP_3,        TD(TD_ENTER_LAYER), \
-  KC_NO,   KC_KP_0,  KC_KP_DOT,      KC_NO \
+  KC_KP_0, KC_KP_0,  KC_KP_DOT,      KC_NO \
   ),
   // Function layer (numpad)
   [_FUNC] = LAYOUT(


### PR DESCRIPTION
Add KC_KP_0 to empty 2U slot which makes the build experience a bit better for those building with 2U keys.