### PR TITLE
Fix reversed encoder 1 rotation in all keymaps

### DIFF
--- a/config.h
+++ b/config.h
@@ -34,8 +34,8 @@
 // You can mix/match pins within the ENCODERS_PAD_A and ENCODERS_PAD_B defines.
 
 // Encoder 1 Pins:
-// #define ENCODERS_PAD_A { B2 }
-// #define ENCODERS_PAD_B { B3 }
+// #define ENCODERS_PAD_A { B3 }
+// #define ENCODERS_PAD_B { B2 }
 
 // Encoder 2 Pins:
 // #define ENCODERS_PAD_A { B4 }

--- a/keymaps/14seg/config.h
+++ b/keymaps/14seg/config.h
@@ -16,5 +16,5 @@
 
 
 // Encoders are defined in order. 1: B2 & B3, 2: B4 & B5, 3: D0 & D1, 4: D2 & D3
-#define ENCODERS_PAD_A { B2 }
-#define ENCODERS_PAD_B { B3 }
+#define ENCODERS_PAD_A { B3 }
+#define ENCODERS_PAD_B { B2 }

--- a/keymaps/4rotary/config.h
+++ b/keymaps/4rotary/config.h
@@ -17,5 +17,5 @@
 #define TAPPING_TERM 200
 
 // Encoders are defined in order. 1: B2 & B3, 2: B4 & B5, 3: D0 & D1, 4: D2 & D3
-#define ENCODERS_PAD_A { B2, B4, D0, D2 }
-#define ENCODERS_PAD_B { B3, B5, D1, D3 }
+#define ENCODERS_PAD_A { B3, B4, D0, D2 }
+#define ENCODERS_PAD_B { B2, B5, D1, D3 }

--- a/keymaps/default/config.h
+++ b/keymaps/default/config.h
@@ -16,5 +16,5 @@
 
 #define TAPPING_TERM 200
 
-#define ENCODERS_PAD_A { B2 }
-#define ENCODERS_PAD_B { B3 }
+#define ENCODERS_PAD_A { B3 }
+#define ENCODERS_PAD_B { B2 }

--- a/keymaps/oled/config.h
+++ b/keymaps/oled/config.h
@@ -17,5 +17,5 @@
 #define TAPPING_TERM 200
 
 // Encoders are defined in order. 1: B2 & B3, 2: B4 & B5, 3: D0 & D1, 4: D2 & D3
-#define ENCODERS_PAD_A { B2 }
-#define ENCODERS_PAD_B { B3 }
+#define ENCODERS_PAD_A { B3 }
+#define ENCODERS_PAD_B { B2 }

--- a/keymaps/via/config.h
+++ b/keymaps/via/config.h
@@ -16,5 +16,5 @@
 
 
 // Encoders are defined in order. 1: B2 & B3, 2: B4 & B5, 3: D0 & D1, 4: D2 & D3
-#define ENCODERS_PAD_A { B2 }
-#define ENCODERS_PAD_B { B3 }
+#define ENCODERS_PAD_A { B3 }
+#define ENCODERS_PAD_B { B2 }


### PR DESCRIPTION
Encoders in position 1 (the topmost encoder) are reversed on the latest PCBs. 